### PR TITLE
created share options

### DIFF
--- a/src/components/ui/GameComponents/SetupComponent.tsx
+++ b/src/components/ui/GameComponents/SetupComponent.tsx
@@ -21,6 +21,13 @@ import { TextField } from "@mui/material";
 import React, { useMemo } from "react";
 import HintComponent from "../HintComponent";
 import GameGetDTO from "models/GameGetDTO";
+import DeleteIcon from '@mui/icons-material/Delete';
+import InfoIcon from '@mui/icons-material/Info';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import {string} from "yup";
+import ClickAwayListener from '@mui/material/ClickAwayListener';
 
 interface Props {
   gameGetDTO: GameGetDTO | null;
@@ -30,9 +37,36 @@ const GuessingComponent: React.FC<Props> = (props) => {
   console.log("GuessingComponent props: ", props);
   const game = props.gameGetDTO;
   const userId = localStorage.getItem("userId");
+  const url = window.location.href
+  var gameID = game?.gameId;
+  console.log("url:")
+
+  console.log(url)
+
+  const [open, setOpen] = React.useState(false);
+  const [openLink, setOpenLink] = React.useState(false);
+
+
+  const handleTooltipCloseGameId = () => {
+    setOpen(false);
+  };
+
+  const handleTooltipOpenGameId = () => {
+    setOpen(true);
+  };
+
+  const handleTooltipCloseGameLink = () => {
+    setOpenLink(false);
+  };
+
+  const handleTooltipOpenGameLink = () => {
+    setOpenLink(true);
+  };
+
 
   async function startGame(): Promise<void> {
     try {
+
       const request = await api.put(
         `/games/${game ? game.gameId : null}/start`,
         userId
@@ -41,6 +75,15 @@ const GuessingComponent: React.FC<Props> = (props) => {
     } catch (error: AxiosError | any) {
       console.log(error);
     }
+  }
+  function createGameId() {
+
+    if (game != null){
+      if(game.gameId != undefined ){
+        navigator.clipboard.writeText(game.gameId.toString())
+      }
+    }
+
   }
 
   return (
@@ -52,7 +95,7 @@ const GuessingComponent: React.FC<Props> = (props) => {
         justifyContent: "center",
       }}
     >
-      <Typography variant="h2">Game Settings</Typography>
+      <Typography variant="h2">Game Lobby</Typography>
       <Box
         sx={{
           display: "flex",
@@ -63,6 +106,59 @@ const GuessingComponent: React.FC<Props> = (props) => {
       <FormControl>
         <DialogContent>
           <FormControl sx={{ minWidth: "200px", marginBottom: "1rem" }}>
+            <Typography variant="h5">You can share this game code, so your friends can join it. <Tooltip title="You can join a lobby using your code when clicking on the 'Join a lobby' button on the Dashboard or use the created link">
+              <IconButton>
+                <InfoIcon />
+              </IconButton>
+            </Tooltip></Typography>
+            <Box
+                component="form"
+                sx={{
+                  '& > :not(style)': { m: 1, width: '20ch' },
+                }}
+                noValidate
+                autoComplete="off"
+            >
+              <TextField disabled id="outlined-basic" color="primary" label="Game Id" variant="filled"  defaultValue={game?.gameId}/>
+              <Tooltip
+                  PopperProps={{
+                    disablePortal: true,
+                  }}
+                  onClose={handleTooltipCloseGameId}
+                  open={open}
+                  disableFocusListener
+                  disableHoverListener
+                  disableTouchListener
+                  title="Copied Game ID!"
+              >
+                <Button variant="contained" color="success" endIcon={<ContentCopyIcon />}
+                        onClick={() => {createGameId();handleTooltipOpenGameId();}}
+                >
+                  Copy Game Id
+                </Button>
+              </Tooltip>
+
+              <TextField disabled id="outlined-basic" color="secondary" label="Link" variant="filled"  defaultValue={url}/>
+              <Tooltip
+                  PopperProps={{
+                    disablePortal: true,
+                  }}
+                  onClose={handleTooltipCloseGameLink}
+                  open={openLink}
+                  disableFocusListener
+                  disableHoverListener
+                  disableTouchListener
+                  title="Copied Game Link!"
+              >
+              <Button variant="contained" color="success" endIcon={<ContentCopyIcon />}
+                      onClick={() => {navigator.clipboard.writeText(url); handleTooltipOpenGameLink();}}>
+                Copy Game Link
+              </Button>
+              </Tooltip>
+
+            </Box>
+            <Typography variant="h2">Game Settings</Typography>
+
             <TextField
               id="round-seconds"
               label="Round Seconds"


### PR DESCRIPTION
-closes #53
-user can share the gamecode/ID or gameLink by either copying it out of the textfield or using a button -the textfields cannot be edited (=disabled)
-when using the button, the user gets a tooltip ("Copied Game ID!") so the user knows, that the button got successfully clicked